### PR TITLE
Block __proto__, constructor and prototype keys in customiser

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,7 +1,13 @@
 import assignWith from 'lodash/assignWith.js'
 import { isPlainObject, isDefined } from 'typical'
 
+const FORBIDDEN_KEYS = new Set(['__proto__', 'constructor', 'prototype'])
+
 function customiser (previousValue, newValue, key, object, source) {
+  /* refuse to merge into prototype-affecting keys */
+  if (FORBIDDEN_KEYS.has(key)) {
+    return previousValue
+  }
   /* deep merge plain objects */
   if (isPlainObject(previousValue) && isPlainObject(newValue)) {
     return assignWith(previousValue, newValue, customiser)

--- a/test.js
+++ b/test.js
@@ -73,5 +73,19 @@ test.set('new class instance not created', function () {
   a.equal(result.arr, arr)
 })
 
+test.set('does not pollute Object.prototype via __proto__', function () {
+  const payload = JSON.parse('{"__proto__":{"polluted":"yes"}}')
+  deepMerge({}, payload)
+  a.equal({}.polluted, undefined)
+  a.equal(Object.prototype.polluted, undefined)
+})
+
+test.set('does not pollute Object.prototype via nested __proto__', function () {
+  const payload = JSON.parse('{"a":{"__proto__":{"polluted":"yes"}}}')
+  deepMerge({ a: {} }, payload)
+  a.equal({}.polluted, undefined)
+  a.equal(Object.prototype.polluted, undefined)
+})
+
 export { test, only, skip }
 


### PR DESCRIPTION
Picks up from your reply to the disclosure email about the CVE-2024-38986 fix bypass.

### What's still wrong on 1.1.3

The 1.1.2 fix only swapped `lodash.assignwith` for `lodash/assignWith.js`. Both walk every own property of the source. When the source comes from `JSON.parse`, `__proto__` is a real own enumerable property, so the customiser is invoked with `key = "__proto__"`, sees two plain objects, and recurses, polluting `Object.prototype`.

PoC against 1.1.3 before this PR:

```js
import deepMerge from '@75lb/deep-merge'
deepMerge({}, JSON.parse('{"__proto__":{"polluted":"yes"}}'))
console.log(({}).polluted)  // "yes"
```

### The fix

One small guard at the top of the customiser that refuses to merge into `__proto__`, `constructor` or `prototype`. Returning `previousValue` makes lodash assign the existing value back, so no write happens.

```js
const FORBIDDEN_KEYS = new Set(['__proto__', 'constructor', 'prototype'])

function customiser (previousValue, newValue, key, object, source) {
  if (FORBIDDEN_KEYS.has(key)) {
    return previousValue
  }
  // ...existing logic unchanged
}
```

`constructor` and `prototype` are not currently exploitable through this code path but block them too to stay defensive against future changes.

### Tests

All six existing tests still pass. Two regression tests added:

- `does not pollute Object.prototype via __proto__`
- `does not pollute Object.prototype via nested __proto__`

### Compatibility

`Set` is supported on every Node `>=12.17` covered by the package.json `engines` field. No new dependencies, no API change, no behaviour change for any merge that does not target a prototype key.
